### PR TITLE
launchpad.net/goyaml moved to gopkg.in/yaml.v1

### DIFF
--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -2,7 +2,7 @@ package metricshipper
 
 import (
 	"fmt"
-	yaml "launchpad.net/goyaml"
+	yaml "gopkg.in/yaml.v1"
 	"reflect"
 	"strings"
 	"testing"


### PR DESCRIPTION
goyaml moved from:
  https://launchpad.net/goyaml
to:
  https://github.com/go-yaml/yaml
