### PR TITLE
ensure ubuntu version matches apt/sources.list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu
+FROM ubuntu:trusty
 MAINTAINER Zenoss, Inc <dev@zenoss.com>
 
-RUN echo 'deb http://archive.ubuntu.com/ubuntu precise main universe' > /etc/apt/sources.list
+RUN echo 'deb http://archive.ubuntu.com/ubuntu trusty main universe' > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y -q wget git-core make mercurial bzr
 RUN apt-get install -y -q redis-server


### PR DESCRIPTION
ISSUE:
  the zenoss/metricshipper-build was being built with 'trusty' with a 'precise' apt/sources.list

DEMO:

```
# plu@plu-9: make dockertest
...
# plu@plu-9: docker run -v ${PWD}:/gosrc/src/github.com/zenoss/metricshipper -i -t zenoss/metricshipper-build /bin/bash
root@26cd8ca300c0:/gosrc/src/github.com/zenoss/metricshipper# cat /etc/issue
Ubuntu 14.04 LTS \n \l

root@26cd8ca300c0:/gosrc/src/github.com/zenoss/metricshipper# cat /etc/apt/sources.list
deb http://archive.ubuntu.com/ubuntu trusty main universe
root@26cd8ca300c0:/gosrc/src/github.com/zenoss/metricshipper# redis-cli --version
redis-cli 2.8.4
```
