### PR TITLE
do not log meanRate; fix misleading log labels

### DIFF
--- a/lib/stats.go
+++ b/lib/stats.go
@@ -123,7 +123,7 @@ func generateMeterMetrics(meter *metrics.Meter, infix string, tags map[string]in
 	metrics = append(metrics, toMetric(fmt.Sprintf("%s.15MinuteRate", prefix), (*meter).Rate15(), tags))
 	metrics = append(metrics, toMetric(fmt.Sprintf("%s.meanRate", prefix), (*meter).RateMean(), tags))
 
-	glog.Infof("INTERNAL %s: %10.0f %8.1f/s-1m %8.1f/s-5m %8.1f/s-15m",
+	glog.Infof("INTERNAL %s: %10.0f %8.1f/s:1m %8.1f/s:5m %8.1f/s:15m",
 		infix, metrics[0].Value, metrics[1].Value, metrics[2].Value, metrics[3].Value)
 
 	return metrics


### PR DESCRIPTION
internal metrics meanRate is misleading - don't log it, but keep publishing it.

```
I0603 18:41:33.255751 00114 stats.go:127] INTERNAL totalIncoming:   39979163     485.3/s  19946.7/1m  17944.8/5m  15949.8/15m
I0603 18:41:33.255826 00114 stats.go:127] INTERNAL totalOutgoing:   39979145     485.3/s  19947.2/1m  17945.4/5m  15950.1/15m
I0603 18:42:03.258998 00114 stats.go:127] INTERNAL totalIncoming:   40477861     491.2/s  18761.6/1m  17867.2/5m  15989.6/15m
I0603 18:42:03.259079 00114 stats.go:127] INTERNAL totalOutgoing:   40477833     491.2/s  18761.8/1m  17867.7/5m  15989.8/15m
```
