### PR TITLE
ZEN-16125 - Backoff improvements.

### DIFF
--- a/etc/metricshipper.yaml
+++ b/etc/metricshipper.yaml
@@ -58,7 +58,11 @@
 
 # Maximum number of slow-down messages to consider for exponential backoff.
 #
-#maxbackoffsteps: 16
+#maxbackoffsteps: 1200
+
+# Maximum number of milliseconds to wait before sending each batch of metrics.
+#
+#maxbackoffdelay: 10000
 
 # Number of processors to use.
 #

--- a/lib/config.go
+++ b/lib/config.go
@@ -23,8 +23,9 @@ type ShipperConfig struct {
 	MaxBatchSize           int     `long:"max-batch-size" description:"Number of messages to send to the consumer in a single web socket call. This should be smaller than the buffer size." default:"64"`
 	BatchTimeout           float64 `long:"batch-timeout-seconds" description:"Maximum time in seconds to wait for messages from the internal buffer to be ready before making a web socket call with current metrics." default:"1"`
 	Encoding               string  `long:"encoding" description:"Encoding for metric publishing (valid values are 'json' or 'binary')" default:"binary"`
-	BackoffWindow          int     `long:"backoff-window-seconds" description:"Rolling time period in seconds to consider collision messages from the consumer." default:"30"`
-	MaxBackoffSteps        int     `long:"max-backoff-steps" description:"Maximum number of collisions to consider for exponential backoff." default:"8"`
+	BackoffWindow          int     `long:"backoff-window-seconds" description:"Rolling time period in seconds to consider collision messages from the consumer." default:"60"`
+	MaxBackoffSteps        int     `long:"max-backoff-steps" description:"Maximum number of collisions to consider for exponential backoff." default:"1200"`
+	MaxBackoffDelay        int     `long:"max-backoff-delay" description:"Maximum milliseconds per request to wait due to backoff (worst case)." default:"10000"`
 	RetryConnectionTimeout int     `long:"retry-connection-timeout" description:"Sleep time between connection retry in seconds" default:"1"`
 	MaxConnectionAge       int     `long:"max-connection-age" description:"Max lifespan of a websocket connection in seconds" default:"600"`
 	Verbosity              int     `long:"verbosity" short:"v" description:"Set the glog logging verbosity" default:"0"`

--- a/lib/output_test.go
+++ b/lib/output_test.go
@@ -63,7 +63,7 @@ func startServer() {
 func TestConnectFail(t *testing.T) {
 	connected := make(chan bool)
 	go func() {
-		_, err := NewWebsocketPublisher("ws://127.0.0.1:12345/metrics", 1, 1, 1, 1, 1, 999, "admin", "zenoss", "json", 1, 1)
+		_, err := NewWebsocketPublisher("ws://127.0.0.1:12345/metrics", 1, 1, 1, 1, 1, 999, "admin", "zenoss", "json", 1, 1, 1)
 		if err != nil {
 			t.Fatalf("Could not create websocket publisher: %s", err)
 		}
@@ -81,7 +81,7 @@ func TestConnect(t *testing.T) {
 	defer clearBuffer()
 	connected := make(chan bool)
 	go func() {
-		_, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 1, 1, 1, 1, 999, "admin", "zenoss", "json", 1, 1)
+		_, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 1, 1, 1, 1, 999, "admin", "zenoss", "json", 1, 1, 1)
 		if err != nil {
 			t.Fatalf("Could not create websocket publisher: %s", err)
 		}
@@ -97,7 +97,7 @@ func TestConnect(t *testing.T) {
 func TestPublishOne(t *testing.T) {
 	once.Do(startServer)
 	defer clearBuffer()
-	pub, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 1, 1, 1, 1, 999, "admin", "zenoss", "json", 1, 1)
+	pub, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 1, 1, 1, 1, 999, "admin", "zenoss", "json", 1, 1, 1)
 	if err != nil {
 		t.Fatalf("Could not create websocket publisher: %s", err)
 	}
@@ -109,7 +109,7 @@ func TestPublishOne(t *testing.T) {
 func TestHitBatchSize(t *testing.T) {
 	once.Do(startServer)
 	defer clearBuffer()
-	pub, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 6, 3, 1, 1, 999, "admin", "zenoss", "json", 1, 1)
+	pub, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 6, 3, 1, 1, 999, "admin", "zenoss", "json", 1, 1, 1)
 	if err != nil {
 		t.Fatalf("Could not create websocket publisher: %s", err)
 	}
@@ -124,7 +124,7 @@ func TestHitBatchSize(t *testing.T) {
 func TestHitBatchTimeout(t *testing.T) {
 	once.Do(startServer)
 	defer clearBuffer()
-	pub, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 6, 3, 1, 1, 999, "admin", "zenoss", "json", 1, 1)
+	pub, err := NewWebsocketPublisher("ws://"+serverAddr+"/metrics", 1, 6, 3, 1, 1, 999, "admin", "zenoss", "json", 1, 1, 1)
 	if err != nil {
 		t.Fatalf("Could not create websocket publisher: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 		config.Readers, config.MaxBufferSize, config.MaxBatchSize,
 		config.BatchTimeout, time.Duration(config.RetryConnectionTimeout)*time.Second,
 		time.Duration(config.MaxConnectionAge)*time.Second, config.Username, config.Password, config.Encoding,
-		config.BackoffWindow, config.MaxBackoffSteps)
+		config.BackoffWindow, config.MaxBackoffSteps, config.MaxBackoffDelay)
 	if err != nil {
 		glog.Error("Unable to create WebSocket forwarder")
 		return


### PR DESCRIPTION
- Backoff for *COLLISION and DROPPED messages.
- One backoff counter per connection.
- Add MaxBackoffDelay config option.
- Bump default BackoffWindow from 30 to 60 seconds.
- Bump default MaxBackoffSteps from 8 to 1200.
