### PR TITLE
fixes ZEN-17476: log published metrics for glog verbosity 5

### DIFF
--- a/etc/metricshipper.yaml
+++ b/etc/metricshipper.yaml
@@ -71,3 +71,7 @@
 # Timeout between connection retry attempts in seconds
 #
 #retryconnectiontimeout: 1
+
+# Set the glog logging verbosity
+# 
+#verbosity: 0

--- a/lib/output.go
+++ b/lib/output.go
@@ -97,6 +97,12 @@ func (w *WebsocketPublisher) sendBatch(batch *MetricBatch, backoff *Backoff) (me
 	glog.V(3).Infof("enter sendBatch(), conn=%s, len(batch)=%d", w.pool.config.Location, len(batch.Metrics))
 	defer glog.V(3).Infof("exit sendBatch(), num=%d", num)
 
+	if glog.V(5) {
+		for _, m := range batch.Metrics {
+			glog.V(5).Infof("publishing: %+v", m)
+		}
+	}
+
 	switch strings.ToLower(w.encoding) {
 	case "json":
 		bytes, err = websocket.JSON.Send(conn.conn, batch)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-17476

DEMO - sample log output from metricshipper.log for metricshipper.yaml "verbosity: 5":

```
[root@resmgr-501 ~]# serviced service edit host/metricshipper
    # append "verbosity: 5\n" to "Content" of "ConfigFiles" for metricshipper.yaml
[root@resmgr-501 ~]# serviced service restart host/metricshipper
[root@resmgr-501 ~]# serviced service attach host/metricshipper/0 tail -F /opt/zenoss/log/metricshipper.log | egrep 'publishing|sendBatch'
...
I0507 16:18:02.689833 00036 output.go:97] enter sendBatch(), conn=ws://localhost:8080/ws/metrics/store, len(batch)=12
I0507 16:18:02.689878 00036 output.go:102] publishing: {Timestamp:1.43101548070118e+09 Metric:modeledDevices Value:264 Tags:map[monitor:localhost metricType:DERIVE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true daemon:zenmodeler]}
I0507 16:18:02.689916 00036 output.go:102] publishing: {Timestamp:1.4310154809081e+09 Metric:dataPoints Value:213868 Tags:map[metricType:DERIVE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true daemon:zenjmx monitor:localhost]}
I0507 16:18:02.689937 00036 output.go:102] publishing: {Timestamp:1.43101548090806e+09 Metric:taskCount Value:1 Tags:map[instance:0 internal:true daemon:zenjmx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf]}
I0507 16:18:02.689948 00036 output.go:102] publishing: {Timestamp:1.43101548090802e+09 Metric:devices Value:0 Tags:map[daemon:zenjmx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true]}
I0507 16:18:02.689962 00036 output.go:102] publishing: {Timestamp:1.43101548090792e+09 Metric:runningTasks Value:0 Tags:map[daemon:zenjmx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true]}
I0507 16:18:02.689975 00036 output.go:102] publishing: {Timestamp:1.43101548100116e+09 Metric:missedRuns Value:0 Tags:map[monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true daemon:zenwebtx]}
I0507 16:18:02.689989 00036 output.go:102] publishing: {Timestamp:1.43101548100112e+09 Metric:queuedTasks Value:0 Tags:map[internal:true daemon:zenwebtx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0]}
I0507 16:18:02.690002 00036 output.go:102] publishing: {Timestamp:1.43101548100107e+09 Metric:dataPoints Value:213866 Tags:map[internal:true daemon:zenwebtx monitor:localhost metricType:DERIVE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0]}
I0507 16:18:02.690015 00036 output.go:102] publishing: {Timestamp:1.43101548100103e+09 Metric:taskCount Value:1 Tags:map[metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true daemon:zenwebtx monitor:localhost]}
I0507 16:18:02.690029 00036 output.go:102] publishing: {Timestamp:1.43101548100098e+09 Metric:devices Value:0 Tags:map[instance:0 internal:true daemon:zenwebtx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf]}
I0507 16:18:02.690042 00036 output.go:102] publishing: {Timestamp:1.43101548100089e+09 Metric:runningTasks Value:0 Tags:map[daemon:zenwebtx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true]}
I0507 16:18:02.690055 00036 output.go:102] publishing: {Timestamp:1.43101548033845e+09 Metric:eventQueueLength Value:0 Tags:map[daemon:zenwebtx monitor:localhost metricType:GAUGE tenantId:aou4p8ic4ljm03k0kp6vrugdf instance:0 internal:true]}
I0507 16:18:02.690273 00036 output.go:120] exit sendBatch(), num=12
...
I0507 16:21:06.942648 00036 output.go:97] enter sendBatch(), conn=ws://localhost:8080/ws/metrics/store, len(batch)=64
I0507 16:21:06.942656 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOperStatus_ifOperStatus Value:1 Tags:map[device:10.171.100.88 contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5 key:Devices/10.171.100.88/os/interfaces/Vethernet7]}
I0507 16:21:06.942671 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:5.482517e+06 Tags:map[key:Devices/10.171.100.88/os/interfaces/Vethernet15 device:10.171.100.88 contextUUID:7835aea2-b501-41bd-9592-37f5ec41302e]}
I0507 16:21:06.942682 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:1.434049119e+09 Tags:map[device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63 key:Devices/10.171.100.88/os/interfaces/Vethernet17]}
I0507 16:21:06.942693 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.525472e+06 Tags:map[device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63 key:Devices/10.171.100.88/os/interfaces/Vethernet17]}
I0507 16:21:06.942704 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cvnVethIfAdditionalState_cvnVethIfAdditionalState Value:5 Tags:map[device:10.171.100.88 contextUUID:12925f68-1f09-4046-b1ce-2da300de07b9 key:Devices/10.171.100.88/os/interfaces/Vethernet9]}
I0507 16:21:06.942716 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:5.526356e+06 Tags:map[device:10.171.100.88 contextUUID:dc030dd3-f017-4ac4-90b4-aa6ea5e99ade key:Devices/10.171.100.88/os/interfaces/control0]}
I0507 16:21:06.942727 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:1.5855985e+07 Tags:map[contextUUID:e7476c3d-e10f-4e85-bb2d-6b18a30eee6f key:Devices/10.171.100.88/os/interfaces/port-channel7 device:10.171.100.88]}
I0507 16:21:06.942737 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOperStatus_ifOperStatus Value:1 Tags:map[key:Devices/10.171.100.88/os/interfaces/Vethernet17 device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63]}
I0507 16:21:06.942748 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:6.782186e+06 Tags:map[device:10.171.100.88 contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5 key:Devices/10.171.100.88/os/interfaces/Vethernet7]}
I0507 16:21:06.942833 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInDiscards_ifInDiscards Value:1.0654476e+07 Tags:map[device:10.171.100.88 contextUUID:4c16cd92-c878-487f-bf4c-588a5eb5c32d key:Devices/10.171.100.88/os/interfaces/Ethernet4_3]}
I0507 16:21:06.942855 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:8.057182e+06 Tags:map[device:10.171.100.88 contextUUID:a574d752-58e9-4027-8473-a0a556c2e69a key:Devices/10.171.100.88/os/interfaces/Ethernet3_4]}
I0507 16:21:06.942866 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.479483e+06 Tags:map[device:10.171.100.88 contextUUID:2bb9340f-d494-4b20-aa9f-efaff7459b5f key:Devices/10.171.100.88/os/interfaces/Ethernet5_2]}
I0507 16:21:06.942879 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:5.5545053e+07 Tags:map[device:10.171.100.88 contextUUID:a574d752-58e9-4027-8473-a0a556c2e69a key:Devices/10.171.100.88/os/interfaces/Ethernet3_4]}
I0507 16:21:06.942889 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInErrors_ifInErrors Value:5.53329e+06 Tags:map[contextUUID:dc030dd3-f017-4ac4-90b4-aa6ea5e99ade key:Devices/10.171.100.88/os/interfaces/control0 device:10.171.100.88]}
I0507 16:21:06.942900 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInDiscards_ifInDiscards Value:1.1357399e+07 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.942911 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:2.6811895e+07 Tags:map[device:10.171.100.88 contextUUID:a574d752-58e9-4027-8473-a0a556c2e69a key:Devices/10.171.100.88/os/interfaces/Ethernet3_4]}
I0507 16:21:06.942922 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:1.1744849e+07 Tags:map[device:10.171.100.88 contextUUID:07f21cee-c347-44a8-bc91-6a93a0880da6 key:Devices/10.171.100.88/os/interfaces/port-channel3]}
I0507 16:21:06.942933 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInErrors_ifInErrors Value:5.521252e+06 Tags:map[device:10.171.100.88 contextUUID:12925f68-1f09-4046-b1ce-2da300de07b9 key:Devices/10.171.100.88/os/interfaces/Vethernet9]}
I0507 16:21:06.942944 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:1.002461e+07 Tags:map[device:10.171.100.88 contextUUID:2d50e582-8a04-4abf-b113-ebacff5e082f key:Devices/10.171.100.88/os/interfaces/port-channel1]}
I0507 16:21:06.942954 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:1.348943e+07 Tags:map[device:10.171.100.88 contextUUID:b1ef5fe9-828c-4b2b-88ae-bb9be3339b6f key:Devices/10.171.100.88/os/interfaces/port-channel2]}
I0507 16:21:06.942964 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:5.51196e+06 Tags:map[key:Devices/10.171.100.88/os/interfaces/Vethernet10 device:10.171.100.88 contextUUID:6ee84f4f-c71c-46e2-ba49-8f2140862df1]}
I0507 16:21:06.942980 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.497115e+06 Tags:map[device:10.171.100.88 contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5 key:Devices/10.171.100.88/os/interfaces/Vethernet7]}
I0507 16:21:06.942995 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:3.310622521e+09 Tags:map[device:10.171.100.88 contextUUID:a574d752-58e9-4027-8473-a0a556c2e69a key:Devices/10.171.100.88/os/interfaces/Ethernet3_4]}
I0507 16:21:06.943006 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutMulticastPkts_ifHCOutMulticastPkts Value:5.540258e+06 Tags:map[contextUUID:4c16cd92-c878-487f-bf4c-588a5eb5c32d key:Devices/10.171.100.88/os/interfaces/Ethernet4_3 device:10.171.100.88]}
I0507 16:21:06.943017 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cefcModuleUpTime_cefcModuleUpTime Value:4.887599e+06 Tags:map[device:10.171.100.88 contextUUID:4394d843-65ed-4480-ade8-abd646caa736 key:Devices/10.171.100.88/hw/cards/Virtual Supervisor Module 2]}
I0507 16:21:06.943027 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:5.513715e+06 Tags:map[device:10.171.100.88 contextUUID:fdb54607-fcea-42f3-b4fc-44c94e58c8b2 key:Devices/10.171.100.88/os/interfaces/Vethernet16]}
I0507 16:21:06.943038 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:5.538276e+06 Tags:map[key:Devices/10.171.100.88/os/interfaces/port-channel5 device:10.171.100.88 contextUUID:d2f3e0eb-3c86-4355-b2ec-af22cb00eb4d]}
I0507 16:21:06.943049 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInDiscards_ifInDiscards Value:5.486783e+06 Tags:map[device:10.171.100.88 contextUUID:a367c77f-1d6b-471b-b68e-46bb7b33d828 key:Devices/10.171.100.88/os/interfaces/Ethernet10_1]}
I0507 16:21:06.943059 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:9.971296e+06 Tags:map[device:10.171.100.88 contextUUID:e7476c3d-e10f-4e85-bb2d-6b18a30eee6f key:Devices/10.171.100.88/os/interfaces/port-channel7]}
I0507 16:21:06.943070 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:5.504189e+06 Tags:map[device:10.171.100.88 contextUUID:b6ebfbfe-ea44-4ec9-83cf-fdb7391499e5 key:Devices/10.171.100.88/os/interfaces/Vethernet1]}
I0507 16:21:06.943080 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:3.316837715e+09 Tags:map[device:10.171.100.88 contextUUID:d1602d57-2d27-447e-bf50-a73a6b6fbb8f key:Devices/10.171.100.88/os/interfaces/Ethernet4_4]}
I0507 16:21:06.943091 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:5.9091525e+07 Tags:map[contextUUID:07f21cee-c347-44a8-bc91-6a93a0880da6 key:Devices/10.171.100.88/os/interfaces/port-channel3 device:10.171.100.88]}
I0507 16:21:06.943101 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:3.084248e+07 Tags:map[key:Devices/10.171.100.88/os/interfaces/port-channel4 device:10.171.100.88 contextUUID:01495d73-3774-43c3-87ca-99f1f708e30f]}
I0507 16:21:06.943114 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:5.567435e+06 Tags:map[device:10.171.100.88 contextUUID:d2f3e0eb-3c86-4355-b2ec-af22cb00eb4d key:Devices/10.171.100.88/os/interfaces/port-channel5]}
I0507 16:21:06.943127 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:5.581462e+06 Tags:map[device:10.171.100.88 contextUUID:721b95ce-5518-4124-8e57-ec8991de5139 key:Devices/10.171.100.88/os/interfaces/port-channel6]}
I0507 16:21:06.943138 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:3.031231e+07 Tags:map[contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3 device:10.171.100.88]}
I0507 16:21:06.943148 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:2.5389976e+07 Tags:map[device:10.171.100.88 contextUUID:12925f68-1f09-4046-b1ce-2da300de07b9 key:Devices/10.171.100.88/os/interfaces/Vethernet9]}
I0507 16:21:06.943159 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:2.6775387e+07 Tags:map[key:Devices/10.171.100.88/os/interfaces/port-channel1 device:10.171.100.88 contextUUID:2d50e582-8a04-4abf-b113-ebacff5e082f]}
I0507 16:21:06.943169 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:5.50708e+06 Tags:map[device:10.171.100.88 contextUUID:d1602d57-2d27-447e-bf50-a73a6b6fbb8f key:Devices/10.171.100.88/os/interfaces/Ethernet4_4]}
I0507 16:21:06.943180 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:3.265875741e+09 Tags:map[device:10.171.100.88 contextUUID:f49a7a9f-04d7-4074-a1db-25ffceb22706 key:Devices/10.171.100.88/os/interfaces/Ethernet6_2]}
I0507 16:21:06.943190 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutMulticastPkts_ifHCOutMulticastPkts Value:5.543715e+06 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.943201 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:1.3331296e+07 Tags:map[device:10.171.100.88 contextUUID:e7476c3d-e10f-4e85-bb2d-6b18a30eee6f key:Devices/10.171.100.88/os/interfaces/port-channel7]}
I0507 16:21:06.943211 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:5.521786e+06 Tags:map[device:10.171.100.88 contextUUID:d2f3e0eb-3c86-4355-b2ec-af22cb00eb4d key:Devices/10.171.100.88/os/interfaces/port-channel5]}
I0507 16:21:06.943222 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:5.522698e+06 Tags:map[device:10.171.100.88 contextUUID:721b95ce-5518-4124-8e57-ec8991de5139 key:Devices/10.171.100.88/os/interfaces/port-channel6]}
I0507 16:21:06.943232 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:5.504576e+06 Tags:map[device:10.171.100.88 contextUUID:12925f68-1f09-4046-b1ce-2da300de07b9 key:Devices/10.171.100.88/os/interfaces/Vethernet9]}
I0507 16:21:06.943242 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:1.112342149e+09 Tags:map[device:10.171.100.88 contextUUID:2d50e582-8a04-4abf-b113-ebacff5e082f key:Devices/10.171.100.88/os/interfaces/port-channel1]}
I0507 16:21:06.943253 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:5.645283e+06 Tags:map[contextUUID:d1602d57-2d27-447e-bf50-a73a6b6fbb8f key:Devices/10.171.100.88/os/interfaces/Ethernet4_4 device:10.171.100.88]}
I0507 16:21:06.943265 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:1.934574989e+09 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.943275 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:1.0025715e+07 Tags:map[key:Devices/10.171.100.88/os/interfaces/Ethernet6_2 device:10.171.100.88 contextUUID:f49a7a9f-04d7-4074-a1db-25ffceb22706]}
I0507 16:21:06.943286 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:5.51158e+06 Tags:map[device:10.171.100.88 contextUUID:07f21cee-c347-44a8-bc91-6a93a0880da6 key:Devices/10.171.100.88/os/interfaces/port-channel3]}
I0507 16:21:06.943296 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInErrors_ifInErrors Value:5.533762e+06 Tags:map[device:10.171.100.88 contextUUID:a574d752-58e9-4027-8473-a0a556c2e69a key:Devices/10.171.100.88/os/interfaces/Ethernet3_4]}
I0507 16:21:06.943825 00036 output.go:97] enter sendBatch(), conn=ws://localhost:8080/ws/metrics/store, len(batch)=64
I0507 16:21:06.943832 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:7.300718e+06 Tags:map[device:10.171.100.88 contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5 key:Devices/10.171.100.88/os/interfaces/Vethernet7]}
I0507 16:21:06.943847 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInErrors_ifInErrors Value:5.522804e+06 Tags:map[device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63 key:Devices/10.171.100.88/os/interfaces/Vethernet17]}
I0507 16:21:06.943858 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:5.533221e+06 Tags:map[device:10.171.100.88 contextUUID:7835aea2-b501-41bd-9592-37f5ec41302e key:Devices/10.171.100.88/os/interfaces/Vethernet15]}
I0507 16:21:06.943869 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.516174e+06 Tags:map[contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3 device:10.171.100.88]}
I0507 16:21:06.943880 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.52895e+06 Tags:map[device:10.171.100.88 contextUUID:a367c77f-1d6b-471b-b68e-46bb7b33d828 key:Devices/10.171.100.88/os/interfaces/Ethernet10_1]}
I0507 16:21:06.943890 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:4.8455531e+07 Tags:map[device:10.171.100.88 contextUUID:d1602d57-2d27-447e-bf50-a73a6b6fbb8f key:Devices/10.171.100.88/os/interfaces/Ethernet4_4]}
I0507 16:21:06.943900 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:5.512549e+06 Tags:map[device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63 key:Devices/10.171.100.88/os/interfaces/Vethernet17]}
I0507 16:21:06.943911 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:5.557747e+06 Tags:map[device:10.171.100.88 contextUUID:7835aea2-b501-41bd-9592-37f5ec41302e key:Devices/10.171.100.88/os/interfaces/Vethernet15]}
I0507 16:21:06.943922 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutMulticastPkts_ifHCOutMulticastPkts Value:5.623922e+06 Tags:map[device:10.171.100.88 contextUUID:f49a7a9f-04d7-4074-a1db-25ffceb22706 key:Devices/10.171.100.88/os/interfaces/Ethernet6_2]}
I0507 16:21:06.943932 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOperStatus_ifOperStatus Value:2 Tags:map[key:Devices/10.171.100.88/os/interfaces/Vethernet10 device:10.171.100.88 contextUUID:6ee84f4f-c71c-46e2-ba49-8f2140862df1]}
I0507 16:21:06.943943 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutMulticastPkts_ifHCOutMulticastPkts Value:6.135677e+06 Tags:map[device:10.171.100.88 contextUUID:fdb54607-fcea-42f3-b4fc-44c94e58c8b2 key:Devices/10.171.100.88/os/interfaces/Vethernet16]}
I0507 16:21:06.943307 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.530604e+06 Tags:map[device:10.171.100.88 contextUUID:2d50e582-8a04-4abf-b113-ebacff5e082f key:Devices/10.171.100.88/os/interfaces/port-channel1]}
I0507 16:21:06.943953 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cvnVethIfAdditionalState_cvnVethIfAdditionalState Value:5 Tags:map[device:10.171.100.88 contextUUID:7835aea2-b501-41bd-9592-37f5ec41302e key:Devices/10.171.100.88/os/interfaces/Vethernet15]}
I0507 16:21:06.943956 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:1.9947059e+07 Tags:map[device:10.171.100.88 contextUUID:b1ef5fe9-828c-4b2b-88ae-bb9be3339b6f key:Devices/10.171.100.88/os/interfaces/port-channel2]}
I0507 16:21:06.943964 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:4.381101883e+09 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.943972 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.51812e+06 Tags:map[device:10.171.100.88 contextUUID:fdb54607-fcea-42f3-b4fc-44c94e58c8b2 key:Devices/10.171.100.88/os/interfaces/Vethernet16]}
I0507 16:21:06.943974 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:1.1287915e+07 Tags:map[contextUUID:dc030dd3-f017-4ac4-90b4-aa6ea5e99ade key:Devices/10.171.100.88/os/interfaces/control0 device:10.171.100.88]}
I0507 16:21:06.943983 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:7.686150332e+09 Tags:map[device:10.171.100.88 contextUUID:b1ef5fe9-828c-4b2b-88ae-bb9be3339b6f key:Devices/10.171.100.88/os/interfaces/port-channel2]}
I0507 16:21:06.943989 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:5.575978e+06 Tags:map[device:10.171.100.88 contextUUID:12925f68-1f09-4046-b1ce-2da300de07b9 key:Devices/10.171.100.88/os/interfaces/Vethernet9]}
I0507 16:21:06.943994 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInErrors_ifInErrors Value:5.526886e+06 Tags:map[device:10.171.100.88 contextUUID:2d50e582-8a04-4abf-b113-ebacff5e082f key:Devices/10.171.100.88/os/interfaces/port-channel1]}
I0507 16:21:06.944003 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:5.608248e+06 Tags:map[device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63 key:Devices/10.171.100.88/os/interfaces/Vethernet17]}
I0507 16:21:06.944014 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.516323e+06 Tags:map[key:Devices/10.171.100.88/os/interfaces/Vethernet17 device:10.171.100.88 contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63]}
I0507 16:21:06.944025 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInDiscards_ifInDiscards Value:5.519998e+06 Tags:map[device:10.171.100.88 contextUUID:23994ccc-2784-4481-add0-8205c1f352a0 key:Devices/10.171.100.88/os/interfaces/mgmt0]}
I0507 16:21:06.944036 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cvnVethIfAdditionalState_cvnVethIfAdditionalState Value:5 Tags:map[device:10.171.100.88 contextUUID:b6ebfbfe-ea44-4ec9-83cf-fdb7391499e5 key:Devices/10.171.100.88/os/interfaces/Vethernet1]}
I0507 16:21:06.944047 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:1.0016363e+07 Tags:map[device:10.171.100.88 contextUUID:01495d73-3774-43c3-87ca-99f1f708e30f key:Devices/10.171.100.88/os/interfaces/port-channel4]}
I0507 16:21:06.944005 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:7.42896754e+09 Tags:map[contextUUID:07f21cee-c347-44a8-bc91-6a93a0880da6 key:Devices/10.171.100.88/os/interfaces/port-channel3 device:10.171.100.88]}
I0507 16:21:06.944057 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:3.214639727e+10 Tags:map[device:10.171.100.88 contextUUID:dc030dd3-f017-4ac4-90b4-aa6ea5e99ade key:Devices/10.171.100.88/os/interfaces/control0]}
I0507 16:21:06.944061 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.511574e+06 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.944068 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:5.705243e+06 Tags:map[device:10.171.100.88 contextUUID:a574d752-58e9-4027-8473-a0a556c2e69a key:Devices/10.171.100.88/os/interfaces/Ethernet3_4]}
I0507 16:21:06.944075 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInOctets_ifHCInOctets Value:5.57469e+06 Tags:map[device:10.171.100.88 contextUUID:721b95ce-5518-4124-8e57-ec8991de5139 key:Devices/10.171.100.88/os/interfaces/port-channel6]}
I0507 16:21:06.944078 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.504047e+06 Tags:map[device:10.171.100.88 contextUUID:4c16cd92-c878-487f-bf4c-588a5eb5c32d key:Devices/10.171.100.88/os/interfaces/Ethernet4_3]}
I0507 16:21:06.944086 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.496478e+06 Tags:map[device:10.171.100.88 contextUUID:01495d73-3774-43c3-87ca-99f1f708e30f key:Devices/10.171.100.88/os/interfaces/port-channel4]}
I0507 16:21:06.944089 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:5.539177e+06 Tags:map[contextUUID:7835aea2-b501-41bd-9592-37f5ec41302e key:Devices/10.171.100.88/os/interfaces/Vethernet15 device:10.171.100.88]}
I0507 16:21:06.944096 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:5.484734e+06 Tags:map[device:10.171.100.88 contextUUID:2bb9340f-d494-4b20-aa9f-efaff7459b5f key:Devices/10.171.100.88/os/interfaces/Ethernet5_2]}
I0507 16:21:06.944099 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutDiscards_ifOutDiscards Value:5.501202e+06 Tags:map[device:10.171.100.88 contextUUID:d1602d57-2d27-447e-bf50-a73a6b6fbb8f key:Devices/10.171.100.88/os/interfaces/Ethernet4_4]}
I0507 16:21:06.944107 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutMulticastPkts_ifHCOutMulticastPkts Value:5.8977e+06 Tags:map[contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5 key:Devices/10.171.100.88/os/interfaces/Vethernet7 device:10.171.100.88]}
I0507 16:21:06.944110 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:1.065832987e+09 Tags:map[key:Devices/10.171.100.88/os/interfaces/Ethernet10_1 device:10.171.100.88 contextUUID:a367c77f-1d6b-471b-b68e-46bb7b33d828]}
I0507 16:21:06.944117 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:5.501126e+06 Tags:map[device:10.171.100.88 contextUUID:d2f3e0eb-3c86-4355-b2ec-af22cb00eb4d key:Devices/10.171.100.88/os/interfaces/port-channel5]}
I0507 16:21:06.944120 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:5.501315e+06 Tags:map[device:10.171.100.88 contextUUID:7835aea2-b501-41bd-9592-37f5ec41302e key:Devices/10.171.100.88/os/interfaces/Vethernet15]}
I0507 16:21:06.944128 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInDiscards_ifInDiscards Value:5.47814e+06 Tags:map[device:10.171.100.88 contextUUID:fdb54607-fcea-42f3-b4fc-44c94e58c8b2 key:Devices/10.171.100.88/os/interfaces/Vethernet16]}
I0507 16:21:06.944131 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutBroadcastPkts_ifHCOutBroadcastPkts Value:5.507488e+06 Tags:map[device:10.171.100.88 contextUUID:721b95ce-5518-4124-8e57-ec8991de5139 key:Devices/10.171.100.88/os/interfaces/port-channel6]}
I0507 16:21:06.944186 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:5.5232241e+07 Tags:map[device:10.171.100.88 contextUUID:b1ef5fe9-828c-4b2b-88ae-bb9be3339b6f key:Devices/10.171.100.88/os/interfaces/port-channel2]}
I0507 16:21:06.944201 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInMulticastPkts_ifHCInMulticastPkts Value:5.727284e+07 Tags:map[contextUUID:2d50e582-8a04-4abf-b113-ebacff5e082f key:Devices/10.171.100.88/os/interfaces/port-channel1 device:10.171.100.88]}
I0507 16:21:06.944211 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:2.6933334e+07 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.944222 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cvnVethIfAdditionalState_cvnVethIfAdditionalState Value:2 Tags:map[key:Devices/10.171.100.88/os/interfaces/Vethernet7 device:10.171.100.88 contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5]}
I0507 16:21:06.944232 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:1.984596795e+09 Tags:map[device:10.171.100.88 contextUUID:b1ef5fe9-828c-4b2b-88ae-bb9be3339b6f key:Devices/10.171.100.88/os/interfaces/port-channel2]}
I0507 16:21:06.944243 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:5.555879e+06 Tags:map[device:10.171.100.88 contextUUID:fdb54607-fcea-42f3-b4fc-44c94e58c8b2 key:Devices/10.171.100.88/os/interfaces/Vethernet16]}
I0507 16:21:06.944254 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/sysUpTime_sysUpTime Value:7.9784976e+08 Tags:map[device:10.171.100.88 contextUUID:0a878a48-b715-4054-9e5f-5e1e1ba97877 key:Devices/10.171.100.88]}
I0507 16:21:06.944265 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:5.517335e+06 Tags:map[device:10.171.100.88 contextUUID:721b95ce-5518-4124-8e57-ec8991de5139 key:Devices/10.171.100.88/os/interfaces/port-channel6]}
I0507 16:21:06.944275 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutUcastPkts_ifHCOutUcastPkts Value:1.332728e+07 Tags:map[device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba key:Devices/10.171.100.88/os/interfaces/Ethernet3_3]}
I0507 16:21:06.944285 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.532424e+06 Tags:map[device:10.171.100.88 contextUUID:2bb9340f-d494-4b20-aa9f-efaff7459b5f key:Devices/10.171.100.88/os/interfaces/Ethernet5_2]}
I0507 16:21:06.944295 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutOctets_ifHCOutOctets Value:1.528444855e+09 Tags:map[device:10.171.100.88 contextUUID:07f21cee-c347-44a8-bc91-6a93a0880da6 key:Devices/10.171.100.88/os/interfaces/port-channel3]}
I0507 16:21:06.944306 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cefcFRUCurrent_cefcFRUCurrent Value:498 Tags:map[contextUUID:703325dc-8759-455b-8c09-8ce5d65afb09 key:Devices/10.171.100.88/hw/cards/Virtual Supervisor Module 1 device:10.171.100.88]}
I0507 16:21:06.944321 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cefcFRUCurrent_cefcFRUCurrent Value:498 Tags:map[key:Devices/10.171.100.88/hw/cards/Virtual Supervisor Module 2 device:10.171.100.88 contextUUID:4394d843-65ed-4480-ade8-abd646caa736]}
I0507 16:21:06.944334 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInBroadcastPkts_ifHCInBroadcastPkts Value:5.484719e+06 Tags:map[device:10.171.100.88 contextUUID:12925f68-1f09-4046-b1ce-2da300de07b9 key:Devices/10.171.100.88/os/interfaces/Vethernet9]}
I0507 16:21:06.944346 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifOutErrors_ifOutErrors Value:5.526915e+06 Tags:map[contextUUID:9c11398e-2aa1-43e3-94b7-fda05483aff5 key:Devices/10.171.100.88/os/interfaces/Vethernet7 device:10.171.100.88]}
I0507 16:21:06.944357 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCInUcastPkts_ifHCInUcastPkts Value:1.7442099e+07 Tags:map[key:Devices/10.171.100.88/os/interfaces/Ethernet3_3 device:10.171.100.88 contextUUID:7e90ca98-a018-4505-a544-fba0d9faaaba]}
I0507 16:21:06.944367 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifHCOutMulticastPkts_ifHCOutMulticastPkts Value:6.348202e+06 Tags:map[device:10.171.100.88 contextUUID:b6ebfbfe-ea44-4ec9-83cf-fdb7391499e5 key:Devices/10.171.100.88/os/interfaces/Vethernet1]}
I0507 16:21:06.944379 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/cvnVethIfAdditionalState_cvnVethIfAdditionalState Value:2 Tags:map[contextUUID:56962d7f-e43e-4bb7-b71b-2ff9d6416b63 key:Devices/10.171.100.88/os/interfaces/Vethernet17 device:10.171.100.88]}
I0507 16:21:06.944388 00036 output.go:102] publishing: {Timestamp:1.431015665e+09 Metric:10.171.100.88/ifInErrors_ifInErrors Value:5.514584e+06 Tags:map[device:10.171.100.88 contextUUID:a367c77f-1d6b-471b-b68e-46bb7b33d828 key:Devices/10.171.100.88/os/interfaces/Ethernet10_1]}
I0507 16:21:06.944400 00036 output.go:120] exit sendBatch(), num=64
...
```
