### PR TITLE
Replace 'go clean' in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -122,7 +122,8 @@ rpm: stage_pkg
 	cp -p /tmp/*.rpm .
 
 clean:
-	go clean
+	# go clean
+	rm -f metricshipper metricshipper.exe metricshipper.test metricshipper.test.exe main main.exe main_test main_test.exe
 	rm -f *.deb
 	rm -f *.rpm
 	rm -f *.tgz


### PR DESCRIPTION
Replace a use of 'go clean' in the 'clean' section of the makefile.
In some cases, metricshipper may only be build via docker, so the host
machine may not have go installed. In this case, 'go clean' won't work.