### PR TITLE
Only run go clean if host has go

### DIFF
--- a/makefile
+++ b/makefile
@@ -122,7 +122,11 @@ rpm: stage_pkg
 	cp -p /tmp/*.rpm .
 
 clean:
-	go clean
+	if [[ `which go` ]]; then
+		go clean
+	else
+		rm -f metricshipper metricshipper.exe metricshipper.test metricshipper.test.exe main main.exe main_test main_test.exe
+	fi
 	rm -f *.deb
 	rm -f *.rpm
 	rm -f *.tgz


### PR DESCRIPTION
Otherwise manually remove the artifacts.
That list was generated from 'go clean -n' and will need
to be kept up to date manually.